### PR TITLE
Add width and height attributes to vector assets

### DIFF
--- a/images/vector_icons/action_pin-01.svg
+++ b/images/vector_icons/action_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="action_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/arrow-01.svg
+++ b/images/vector_icons/arrow-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 76.921 80.755" style="enable-background:new 0 0 76.921 80.755;" xml:space="preserve">
+	 viewBox="0 0 76.921 80.755" width="76.921" height="80.755" style="enable-background:new 0 0 76.921 80.755;" xml:space="preserve">
 <g id="arrow">
 	<g>
 		<path style="fill:#303030;stroke:#000000;stroke-width:0.75;stroke-miterlimit:10;" d="M74.807,38.642H5.766L34.113,3.166

--- a/images/vector_icons/basestation_pin-01.svg
+++ b/images/vector_icons/basestation_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="basestation_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/checkmark-01.svg
+++ b/images/vector_icons/checkmark-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 97.5 75.694" style="enable-background:new 0 0 97.5 75.694;" xml:space="preserve">
+	 viewBox="0 0 97.5 75.694" width="97.5" height="75.694" style="enable-background:new 0 0 97.5 75.694;" xml:space="preserve">
 <g id="checkmark">
 	<polyline style="fill:none;stroke:#303030;stroke-width:5;stroke-linecap:round;stroke-miterlimit:10;" points="2.5,43.437 
 		29.462,72.049 95,2.5 	"/>

--- a/images/vector_icons/chevron-01.svg
+++ b/images/vector_icons/chevron-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 44.504 83.814" style="enable-background:new 0 0 44.504 83.814;" xml:space="preserve">
+	 viewBox="0 0 44.504 83.814" width="44.504" height="83.814" style="enable-background:new 0 0 44.504 83.814;" xml:space="preserve">
 <g id="chevron">
 	<path style="fill:#303030;stroke:#000000;stroke-width:0.75;stroke-miterlimit:10;" d="M0.825,80.131l37.137-37.137
 		c0.6-0.6,0.6-1.572,0-2.172L0.825,3.683c-0.6-0.6-0.6-1.572,0-2.172l0.686-0.686c0.6-0.6,1.572-0.6,2.172,0l39.996,39.996

--- a/images/vector_icons/inventory_pin-01.svg
+++ b/images/vector_icons/inventory_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="inventory_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/left_hand_pin-01.svg
+++ b/images/vector_icons/left_hand_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="left_x5F_hand_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/map_pin-01.svg
+++ b/images/vector_icons/map_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="map_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/password-01.svg
+++ b/images/vector_icons/password-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 61.74 85.801" style="enable-background:new 0 0 61.74 85.801;" xml:space="preserve">
+	 viewBox="0 0 61.74 85.801" width="61.74" height="85.801" style="enable-background:new 0 0 61.74 85.801;" xml:space="preserve">
 <g id="password">
 	<path style="fill:#303030;" d="M1.8,85.801C0.808,85.801,0,84.993,0,84V36.271c0-0.992,0.808-1.8,1.8-1.8H8.4v-12
 		C8.411,10.092,18.491,0.012,30.87,0c12.379,0.012,22.459,10.092,22.47,22.471v12h6.601c0.992,0,1.8,0.808,1.8,1.8V84

--- a/images/vector_icons/path_pin-01.svg
+++ b/images/vector_icons/path_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="path_x5F_pin">
 	<g>
 		<path style="fill:#5D6771;" d="M66,130.5c-35.565,0-64.5-28.935-64.5-64.5S30.435,1.5,66,1.5s64.5,28.935,64.5,64.5

--- a/images/vector_icons/settings-01.svg
+++ b/images/vector_icons/settings-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 92.71 92.716" style="enable-background:new 0 0 92.71 92.716;" xml:space="preserve">
+	 viewBox="0 0 92.71 92.716" width="92.71" height="92.716" style="enable-background:new 0 0 92.71 92.716;" xml:space="preserve">
 <g id="settings">
 	<g transform="translate(0,-952.36218)">
 		<path style="fill:#303030;" d="M12.318,1045.078c-3.294,0-6.389-1.281-8.715-3.606c-4.805-4.806-4.805-12.624,0-17.43

--- a/images/vector_icons/tag_pin-01.svg
+++ b/images/vector_icons/tag_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="tag_x5F_pin">
 	<g>
 		<g>

--- a/images/vector_icons/user-01.svg
+++ b/images/vector_icons/user-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 79.496 84.199" style="enable-background:new 0 0 79.496 84.199;" xml:space="preserve">
+	 viewBox="0 0 79.496 84.199" width="79.496" height="84.199" style="enable-background:new 0 0 79.496 84.199;" xml:space="preserve">
 <g id="user">
 	<path style="fill:#303030;" d="M4.334,84.199C1.944,84.199,0,82.255,0,79.865v-14.11c0-1.779,0.968-3.229,2.59-3.877l26.682-11.613
 		c0.517-0.208,0.959-0.744,1.191-1.438c0.211-0.633-0.039-1.368-0.685-2.015c-5.401-5.543-9.028-15.385-9.028-24.494

--- a/images/vector_icons/user_pin-01.svg
+++ b/images/vector_icons/user_pin-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g id="user_x5F_pin">
 	<g>
 		<path style="fill:#5D6771;" d="M66,130.5c-35.565,0-64.5-28.935-64.5-64.5S30.435,1.5,66,1.5s64.5,28.935,64.5,64.5

--- a/images/vector_icons/warning-01.svg
+++ b/images/vector_icons/warning-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 105.825 90.375" style="enable-background:new 0 0 105.825 90.375;" xml:space="preserve">
+	 viewBox="0 0 105.825 90.375" width="105.825" height="90.375" style="enable-background:new 0 0 105.825 90.375;" xml:space="preserve">
 <g id="warning">
 	<g>
 		<path style="fill:#303030;" d="M2.161,90.375c-0.799,0-1.45-0.342-1.836-0.963c-0.434-0.704-0.434-1.416-0.002-2.117L51.075,1.102

--- a/images/vector_icons/x-01.svg
+++ b/images/vector_icons/x-01.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 132 132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
+	 viewBox="0 0 132 132" width="132" height="132" style="enable-background:new 0 0 132 132;" xml:space="preserve">
 <g>
 	<path style="fill:#303030;" d="M30.051,103.999c-0.615,0-1.195-0.239-1.634-0.673c-0.905-0.905-0.905-2.371-0.003-3.273
 		l71.638-71.638c0.436-0.437,1.017-0.677,1.635-0.677c0.618,0,1.199,0.24,1.635,0.677C103.76,28.851,104,29.432,104,30.05


### PR DESCRIPTION
The Google Maps API seems to have issues with SVGs that do not include `width` and `height` attribute on the image. This PR fixes that by adding values for those attributes that match the corresponding values in the `viewBox` attribute.